### PR TITLE
fix: Vercel static deployment — No entrypoint found

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,19 @@
 {
   "version": 2,
+  "builds": [
+    {
+      "src": "apps/jared-octopus/arms/landing/src/public/**",
+      "use": "@vercel/static"
+    }
+  ],
   "routes": [
+    {
+      "src": "/",
+      "dest": "/apps/jared-octopus/arms/landing/src/public/index.html"
+    },
     {
       "src": "/(.*)",
       "dest": "/apps/jared-octopus/arms/landing/src/public/$1"
     }
-  ],
-  "outputDirectory": "apps/jared-octopus/arms/landing/src/public"
+  ]
 }


### PR DESCRIPTION
## Fix: Vercel static deployment

**Error:** `No entrypoint found in output directory`

### Root cause

`outputDirectory` requires a build command. Without one, Vercel scans for an
entrypoint and finds nothing — even if the files exist.

### Fix

Switch to `@vercel/static` builder with an explicit glob:

```json
{
  "version": 2,
  "builds": [
    {
      "src": "apps/jared-octopus/arms/landing/src/public/**",
      "use": "@vercel/static"
    }
  ],
  "routes": [
    { "src": "/", "dest": "/apps/jared-octopus/arms/landing/src/public/index.html" },
    { "src": "/(.*)", "dest": "/apps/jared-octopus/arms/landing/src/public/$1" }
  ]
}
```

No build command needed. No Node server. Pure static.
Merge and redeploy on Vercel.
